### PR TITLE
Remove software-properties-common from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y upgrade
 
 RUN apt-get --no-install-recommends install -y  \
 # most packages
-    nano nodejs npm libgif-dev lsb-release software-properties-common \
+    nano nodejs npm libgif-dev lsb-release \
 # ffmpeg
 # https://trac.ffmpeg.org/wiki/CompilationGuide/Ubuntu#FFmpeg
     # build deps


### PR DESCRIPTION
`software-properties-common` is not used in Debian Trixie, which is the base image for `python:latest` as of Probably when Trixie released. Literally no testing has been done, just observant of a single package being missing bungling the entire image roll.